### PR TITLE
Feature/improve search

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Visual Studio 2017 v15.8
 C# 7.3
 
 ### 仕組み
-[UI Automation](https://msdn.microsoft.com/ja-jp/library/ms753388.aspx) API を利用して、Preview Pane 内のテキストを検索しています。メインロジックは [AutomationHandler.cs](https://github.com/fog-bank/mojp/blob/master/mojp/AutomationHandler.cs#L40) 内の CapturePreviewPane メソッド以下です。
+[UI Automation](https://msdn.microsoft.com/ja-jp/library/ms753388.aspx) API を利用して、Preview Pane 内のテキストを検索しています。メインロジックは [AutomationHandler.cs](https://github.com/fog-bank/mojp/blob/master/mojp/AutomationHandler.cs#L53) 内の CapturePreviewPane メソッド以下です。
 
 ## リファレンス
 * MO で日本語テキストを表示する試みとして、[Magic Online 日本語化計画](http://www.royalcrab.net/wpx/?page_id=38)の影響を受けています。

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,7 @@
     <div>
       <p>
         <a href="https://docs.microsoft.com/ja-jp/dotnet/framework/ui-automation/">UI Automation</a> API を利用して、Preview Pane 内のテキストを検索しています。メインロジックは
-        <a href="https://github.com/fog-bank/mojp/blob/master/mojp/AutomationHandler.cs#L40">AutomationHandler.cs</a> 内の CapturePreviewPane メソッド以下です。
+        <a href="https://github.com/fog-bank/mojp/blob/master/mojp/AutomationHandler.cs#L53">AutomationHandler.cs</a> 内の CapturePreviewPane メソッド以下です。
       </p>
     </div>
     <h3 id="reference">リファレンス</h3>

--- a/mojp/App.xaml.cs
+++ b/mojp/App.xaml.cs
@@ -165,26 +165,21 @@ namespace Mojp
         }
 
         /// <summary>
-        /// 指定した名前のプロセスを探し、そのプロセス ID を取得します。
+        /// 指定した名前のプロセスを探し、最初に見つかった <see cref="Process"/> オブジェクトを返します。
         /// </summary>
         /// <param name="processName">プロセスの名前。</param>
-        /// <param name="id">取得したプロセス ID 。</param>
-        /// <returns>プロセスが見つかった場合は <see langword="true"/> 。</returns>
-        public static bool GetProcessIDByName(string processName, out int id)
+        public static Process GetProcessByName(string processName)
         {
+            Process targetProc = null;
+
             foreach (var proc in Process.GetProcesses())
             {
-                using (proc)
-                {
-                    if (string.Equals(proc.ProcessName, processName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        id = proc.Id;
-                        return true;
-                    }
-                }
+                if (targetProc == null && string.Equals(proc.ProcessName, processName, StringComparison.OrdinalIgnoreCase))
+                    targetProc = proc;
+                else
+                    proc.Dispose();
             }
-            id = 0;
-            return false;
+            return targetProc;
         }
 
         protected override void OnStartup(StartupEventArgs e)

--- a/mojp/AutomationHandler.cs
+++ b/mojp/AutomationHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Windows.Automation;
@@ -54,6 +55,16 @@ namespace Mojp
             /// </summary>
             public void CapturePreviewPane()
             {
+                if (App.Cards.Count == 0)
+                {
+                    ViewModel.InvokeSetMessage(
+                        "同梱のカードテキストデータ (cards.xml) を取得できません。" +
+                        "セキュリティ対策ソフトによってブロックされている可能性があります。" +
+                        Environment.NewLine + "[場所] " + 
+                        Path.Combine(Path.GetDirectoryName(typeof(App).Assembly.Location), "cards.xml"));
+                    return;
+                }
+
                 var currentPreviewWnd = previewWnd;
 
                 // MO のプロセス ID を取得する
@@ -145,7 +156,7 @@ namespace Mojp
             /// </summary>
             public void Release()
             {
-                mtgoProc.Dispose();
+                mtgoProc?.Dispose();
                 mtgoProc = null;
                 eventCacheReq = null;
                 cacheReq = null;

--- a/mojp/AutomationHandler.cs
+++ b/mojp/AutomationHandler.cs
@@ -206,7 +206,7 @@ namespace Mojp
             }
 
             /// <summary>
-            /// 指定した文字列がカード名を指定しているかどうかを調べ、そうならばカードを表示します。
+            /// 指定した文字列がカード名を意味しているかどうかを調べ、そうならばカードを表示します。
             /// </summary>
             private bool TryFetchCard(string value)
             {
@@ -238,9 +238,11 @@ namespace Mojp
                     }
                     else if (!currentCards.Contains(card))
                     {
-                        // 一部の Lv カードで、キーワード能力と同名のカードの名前が検出される問題を回避
+                        // 一部の Lv カードで、キーワード能力と同名のカードの名前が検出される問題や、
+                        // ウギンの運命プロモカードで Catch+Release が表示されてしまう問題を回避
                         if ((card.Name == "Lifelink" && IsKeywordName("Transcendent Master")) ||
-                            (card.Name == "Vigilance" && IsKeywordName("Ikiral Outrider")))
+                            (card.Name == "Vigilance" && IsKeywordName("Ikiral Outrider")) ||
+                            (card.Name == "Release" && IsUginFatePromo()))
                         {
                             return true;
                         }
@@ -316,6 +318,32 @@ namespace Mojp
                         return true;
                 }
                 return false;
+            }
+
+            /// <summary>
+            /// 現在のカードがウギンの運命プロモカードであるかどうかを調べます。
+            /// </summary>
+            /// <returns></returns>
+            private bool IsUginFatePromo()
+            {
+                bool isPromo = false;
+                bool containsCatch = false;
+
+                foreach (string value in IterateTextBlocks())
+                {
+                    switch (value)
+                    {
+                        case "PRM":
+                            isPromo = true;
+                            break;
+
+                        // 分割カード Catch+Release ではない
+                        case "Catch":
+                            containsCatch = true;
+                            break;
+                    }
+                }
+                return isPromo && !containsCatch;
             }
 
             /// <summary>

--- a/mojp/CardTextProcessor.cs
+++ b/mojp/CardTextProcessor.cs
@@ -145,7 +145,7 @@ namespace Mojp
         /// <summary>
         /// 指定した文字列が Ultimate Box Toppers のカード番号であるかどうかを調べ、対応するカード名を返します。
         /// </summary>
-        public static bool CheckIfUltimateBoxToppers(string value, out string cardname)
+        public static bool IsUltimateBoxToppers(string value, out string cardname)
         {
             cardname = null;
 

--- a/mojp/MainViewModel.cs
+++ b/mojp/MainViewModel.cs
@@ -24,7 +24,7 @@ namespace Mojp
         {
             SetMessage(AutoRefresh ?
                 "MO の Preview Pane を探しています" :
-                "MO の Preview Pane を表示させた状態で、右上のカメラアイコンのボタンを押してください");
+                "MO の Preview Pane を表示させた状態で、右クリックから「MO を探す」を選択してください。");
 
             CaptureCommand = new CaptureCommand(this);
             CopyCardNameCommand = new CopyCardNameCommand(this);

--- a/mojp/MainWindow.xaml.cs
+++ b/mojp/MainWindow.xaml.cs
@@ -35,6 +35,9 @@ namespace Mojp
 
         internal void ShowPDMessage(GetPDListResult result)
         {
+            if (App.Cards.Count == 0)
+                result = GetPDListResult.NoCheck;
+
             switch (result)
             {
                 case GetPDListResult.New:

--- a/mojp/Properties/AssemblyInfo.cs
+++ b/mojp/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.31230.5")]
+[assembly: AssemblyFileVersion("2.2.40112.6")]

--- a/mojp/Properties/AssemblyInfo.cs
+++ b/mojp/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.31216.2")]
+[assembly: AssemblyFileVersion("2.2.31228.3")]

--- a/mojp/Properties/AssemblyInfo.cs
+++ b/mojp/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.31214.0")]
+[assembly: AssemblyFileVersion("2.2.31215.1")]

--- a/mojp/Properties/AssemblyInfo.cs
+++ b/mojp/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.31229.4")]
+[assembly: AssemblyFileVersion("2.2.31230.5")]

--- a/mojp/Properties/AssemblyInfo.cs
+++ b/mojp/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.31228.3")]
+[assembly: AssemblyFileVersion("2.2.31229.4")]

--- a/mojp/Properties/AssemblyInfo.cs
+++ b/mojp/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.31215.1")]
+[assembly: AssemblyFileVersion("2.2.31216.2")]

--- a/mojp/appendix.xml
+++ b/mojp/appendix.xml
@@ -28,7 +28,6 @@
 終了ステップの開始時に、このクリーチャーを生け贄に捧げる。</card>
     <card name="Marit Lage" jaName="マリット・レイジ" type="トークン・伝説のクリーチャー ― アバター" pt="20/20" related="Dark Depths">飛行、破壊不能</card>
     <card name="Minor Demon" jaName="マイナー・デーモン" type="トークン・クリーチャー ― デーモン" pt="1/1" related="Boris Devilboon"></card>
-    <card name="Mowu" jaName="Mowu" type="トークン・伝説のクリーチャー ― 猟犬" pt="3/3" related="Jiang Yanggu"></card>
     <card name="Ragavan" jaName="ラガバン" type="トークン・伝説のクリーチャー ― 猿" pt="2/1" related="Kari Zev, Skyship Raider"></card>
     <card name="Stangg Twin" jaName="スタングの双子" type="トークン・伝説のクリーチャー ― 人間・戦士" pt="3/4" related="Stangg"></card>
     <card name="Tombspawn" jaName="屍鬼" type="トークン・クリーチャー ― ゾンビ" pt="2/2" related="Tombstone Stairwell">速攻</card>
@@ -124,6 +123,7 @@ Heavenly Qilinが攻撃するたび、あなたがコントロールしている
     <card name="Jiang Yanggu" jaName="Jiang Yanggu" type="伝説のプレインズウォーカー ― Yanggu" pt="4">[+1]：クリーチャー１体を対象とする。ターン終了時まで、それは+2/+2の修整を受ける。
 [-1]：あなたが《Mowu》という名前のクリーチャーをコントロールしていないなら、《Mowu》という名前の緑の3/3の伝説の猟犬・クリーチャー・トークンを１体生成する。
 [-5]：クリーチャー１体を対象とする。ターン終了時まで、それはトランプルを得て+X/+Xの修整を受ける。Ｘはあなたがコントロールしている土地の総数に等しい。</card>
+    <card name="Mowu" jaName="Mowu" type="トークン・伝説のクリーチャー ― 猟犬" pt="3/3" related="Jiang Yanggu"></card>
     <card name="Leopard-Spotted Jiao" jaName="Leopard-Spotted Jiao" type="クリーチャー ― ビースト" pt="3/1"></card>
     <card name="Feiyi Snake" jaName="Feiyi Snake" type="クリーチャー ― 蛇" pt="2/1">到達（このクリーチャーは飛行を持つクリーチャーをブロックできる。）</card>
     <card name="Sacred White Deer" jaName="Sacred White Deer" type="クリーチャー ― 大鹿" pt="2/2">(３)(緑),(Ｔ)：あなたは４点のライフを得る。この能力は、あなたがYanggu・プレインズウォーカーをコントロールしているときにのみ起動できる。</card>
@@ -490,6 +490,10 @@ Fire-Omen Craneが攻撃するたび、対戦相手がコントロールして�
     <related name="Sphinx's Herald" related="Sphinx Sovereign" />
     <related name="Urborg Panther" related="Feral Shadow|Breathstealer|Spirit of the Night" />
     <related name="Walker of the Wastes" related="Wastes" />
+    <!-- 関連カード (合体) -->
+    <related name="Gisela, the Broken Blade" related="Bruna, the Fading Light|Brisela, Voice of Nightmares" />
+    <related name="Graf Rats" related="Midnight Scavengers|Chittering Host" />
+    <related name="Hanweir Battlements" related="Hanweir Garrison|Hanweir, the Writhing Township" />
     <!-- 関連カード（PW デッキ） -->
     <related name="Liberating Combustion" related="Chandra, Pyrogenius" />
     <related name="Verdant Crescendo" related="Nissa, Nature's Artisan" />
@@ -2832,6 +2836,13 @@ Knowledge Vaultが戦場を離れたとき、Knowledge Vaultにより追放さ�
     <type name="Urza's Mine" type="土地 ― ウルザの・鉱山" />
     <type name="Urza's Power Plant" type="土地 ― ウルザの・魔力炉" />
     <type name="Urza's Tower" type="土地 ― ウルザの・塔" />
+    <!-- 関連カード (合体) -->
+    <related name="Bruna, the Fading Light" related="Gisela, the Broken Blade|Brisela, Voice of Nightmares" />
+    <related name="Brisela, Voice of Nightmares" related="Gisela, the Broken Blade|Bruna, the Fading Light" />
+    <related name="Midnight Scavengers" related="Graf Rats|Chittering Host" />
+    <related name="Chittering Host" related="Graf Rats|Midnight Scavengers" />
+    <related name="Hanweir Garrison" related="Hanweir Battlements|Hanweir, the Writhing Township" />
+    <related name="Hanweir, the Writhing Township" related="Hanweir Battlements|Hanweir Garrison" />
   </replace>
   <remove>
     <!-- ドラフト能力を持つカード -->

--- a/mojp/appendix.xsd
+++ b/mojp/appendix.xsd
@@ -70,6 +70,12 @@
                   <xs:attribute name="type" type="xs:string" use="required" />
                 </xs:complexType>
               </xs:element>
+              <xs:element name="related" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required" />
+                  <xs:attribute name="related" type="xs:string" use="required" />
+                </xs:complexType>
+              </xs:element>
             </xs:sequence>
           </xs:complexType>
         </xs:element>


### PR DESCRIPTION
* 全プロセスリストの取得を最低限にした。
  * MO プロセスが見つかったら、Process オブジェクトを保持。プロセスリストの再評価する代わりに、HasExisted プロパティをチェックする。
* AutomationElement.FindAll を減らした。
  * FindAll をする必要性がある場面だけ FindAll をして、それ以外は AutomationPropertyChangedEventArgs.NewValue だけで判断する。
  * ウギンの運命プロモや一部の Lv カードの不具合を一緒に修正。
* card.xml にアクセスできないときのメッセージを追加。